### PR TITLE
Fix file mapping of the test files

### DIFF
--- a/scripts/4_run_tests.sh
+++ b/scripts/4_run_tests.sh
@@ -8,9 +8,9 @@ utPLSQL-cli/bin/utplsql run ut3_demo/ut3_demo@//127.0.0.1:1521/XE?oracle.net.dis
   -name_subexpression=5 \
   -type_subexpression=6 \
   -test_path=test -regex_expression="(\w+)/(\w+)/(\w+)\.(\w+)\.(\w+)$" \
-  -owner_subexpression=1 \
-  -type_subexpression=5 \
+  -owner_subexpression=3 \
   -name_subexpression=4 \
+  -type_subexpression=5 \
   -f=ut_documentation_reporter  -c \
   -f=ut_coverage_sonar_reporter     -o=coverage.xml \
   -f=ut_sonar_test_reporter         -o=test_results.xml \


### PR DESCRIPTION
Hi,

I noticed that the link to [test results](https://sonarcloud.io/component_measures/metric/tests/list?id=utPLSQL%3AutPLSQL-demo-project) in the README is broken due to incorrect file names in the test report.

This change fixes the value of  `-owner_subexpression` for the test files, ensuring that the test execution report contains the path to the test files.